### PR TITLE
Update GMC Canyon generations: Add Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,6 @@
 
 This repository contains signal set configurations for the GMC Canyon, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the GMC Canyon.
 
-## Generations
-
-The GMC Canyon has gone through three main generations, each bringing significant updates and improvements:
-
-- **First Generation (2004-2012)**: The original Canyon was introduced as a replacement for the GMC Sonoma. It offered a range of engine options including a 2.8L I4, 3.5L I5, and later a 3.7L I5. The first generation featured both regular and extended cab configurations, with rear-wheel or four-wheel drive options. This generation was built on the GMT355 platform shared with the Chevrolet Colorado.
-
-- **Second Generation (2015-2022)**: After a brief hiatus, the Canyon returned completely redesigned on the GMT 31XX platform. This generation featured more refined styling, improved interior quality, and advanced technology features. Engine options included a 2.5L I4, 3.6L V6, and a 2.8L Duramax turbodiesel. Notable trim levels included the upscale Denali and the off-road focused AT4.
-
-- **Third Generation (2023-present)**: The latest generation Canyon received a complete redesign with a bold new exterior design and significantly upgraded interior. It comes exclusively with a 2.7L turbocharged four-cylinder engine producing up to 310 hp in certain trims. The lineup includes the luxury-focused Denali, the AT4 for off-road capability, and the new AT4X as the most capable off-road variant. This generation features advanced technology including a larger infotainment display and enhanced safety features.
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Chevrolet_Colorado"
+
 generations:
   - name: "First Generation"
     start_year: 2004


### PR DESCRIPTION
- Added references array with Chevrolet Colorado Wikipedia article (GMC Canyon shares mechanical commonality and redirects to this page)
- Removed duplicate Generations section from README.md (generation data now lives exclusively in generations.yaml per CLAUDE.md guidelines)
- Verified generation dates match Wikipedia production timeline
